### PR TITLE
Joomla 7 compatibility: inject app/db via service providers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+Skeleton Key 1.2.4
+================================================================================
+~ Joomla 7 compatibility: plugins no longer rely on the removed automatic $app/$db population; application and database are injected through the service providers
+~ Joomla 7 compatibility: the authentication plugin now uses SubscriberInterface and handles the AuthenticationEvent object directly (gated by Joomla version)
+~ Joomla 7 compatibility: the onSkeletonKeyRequestLogin event now passes named arguments
+  Minimum requirement raised to Joomla 4.4.
+
 Skeleton Key 1.2.3
 ================================================================================
 # [HIGH] Wouldn't work on Joomla 6 without the backwards compatibility plugin enabled

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,3 +1,3 @@
-**Joomla 6 compatibility fix.** Skeleton Key would fail silently on Joomla 6 sites unless the Joomla backwards compatibility plugin was enabled. This release fixes the underlying incompatibility so the extension works correctly on Joomla 6 with or without the BC plugin.
+**Joomla 7 compatibility.** Skeleton Key now runs on Joomla 7 without relying on the backwards compatibility plugin. The three plugins no longer depend on Joomla's removed automatic `$app`/`$db` population (application and database are now injected through the service providers), and the authentication plugin uses `SubscriberInterface` and the `AuthenticationEvent` object directly, gated by Joomla version so Joomla 4.4, 5 and 6 keep working exactly as before.
 
-If you are running Joomla 6, this update is strongly recommended.
+The minimum requirement is now Joomla 4.4.

--- a/build/templates/pkg_skeletonkey.xml
+++ b/build/templates/pkg_skeletonkey.xml
@@ -14,7 +14,7 @@
     <url>https://www.akeeba.com</url>
     <packager>Akeeba Ltd</packager>
     <packagerurl>https://www.akeeba.com</packagerurl>
-    <copyright>Copyright (c)2022-2025 Nicholas K. Dionysopoulos / Akeeba Ltd</copyright>
+    <copyright>Copyright (c)2022-2026 Nicholas K. Dionysopoulos / Akeeba Ltd</copyright>
     <license>GNU GPL v3 or later</license>
     <description>PKG_SKELETONKEY_XML_DESCRIPTION</description>
     <blockChildUninstall>true</blockChildUninstall>

--- a/plugins/actionlog/skeletonkey/services/provider.php
+++ b/plugins/actionlog/skeletonkey/services/provider.php
@@ -9,6 +9,7 @@ use Akeeba\Plugin\ActionLog\SkeletonKey\Extension\SkeletonKey;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -36,6 +37,7 @@ return new class implements ServiceProviderInterface {
 				$plugin = new SkeletonKey($subject, $config);
 
 				$plugin->setApplication(Factory::getApplication());
+				$plugin->setDatabase($container->get(DatabaseInterface::class));
 
 				return $plugin;
 			}

--- a/plugins/actionlog/skeletonkey/skeletonkey.xml
+++ b/plugins/actionlog/skeletonkey/skeletonkey.xml
@@ -10,10 +10,10 @@
 	<author>Akeeba Ltd</author>
 	<authorEmail>no-reply@akeeba.com</authorEmail>
 	<authorUrl>https://www.akeeba.com</authorUrl>
-	<copyright>Copyright (c)2022-2025 Nicholas K. Dionysopoulos</copyright>
+	<copyright>Copyright (c)2022-2026 Nicholas K. Dionysopoulos</copyright>
 	<license>GNU GPL v3 or later</license>
-	<creationDate>2026-04-21</creationDate>
-	<version>1.2.3</version>
+	<creationDate>2026-06-20</creationDate>
+	<version>1.2.4</version>
 	<description>PLG_ACTIONLOG_SKELETONKEY_XML_DESCRIPTION</description>
 	<namespace path="src">Akeeba\Plugin\ActionLog\SkeletonKey</namespace>
 

--- a/plugins/actionlog/skeletonkey/src/Extension/SkeletonKey.php
+++ b/plugins/actionlog/skeletonkey/src/Extension/SkeletonKey.php
@@ -48,7 +48,9 @@ class SkeletonKey extends ActionLogPlugin implements SubscriberInterface
 		 * @var  User $user          The user to be logged in as
 		 * @var  bool $createdCookie Was the login cookie created?
 		 */
-		[$currentUser, $user, $createdCookie] = array_values($event->getArguments());
+		$currentUser   = $event->getArgument('controlUser');
+		$user          = $event->getArgument('targetUser');
+		$createdCookie = $event->getArgument('createdCookie');
 
 		// The data to store for this record
 		$data = [

--- a/plugins/authentication/skeletonkey/services/provider.php
+++ b/plugins/authentication/skeletonkey/services/provider.php
@@ -8,7 +8,9 @@
 defined('_JEXEC') || die;
 
 use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -32,7 +34,12 @@ return new class implements ServiceProviderInterface {
 				$config  = (array) PluginHelper::getPlugin('authentication', 'skeletonkey');
 				$subject = $container->get(DispatcherInterface::class);
 
-				return new Skeletonkey($subject, $config);
+				$plugin = new Skeletonkey($subject, $config);
+
+				$plugin->setApplication(Factory::getApplication());
+				$plugin->setDatabase($container->get(DatabaseInterface::class));
+
+				return $plugin;
 			}
 		);
 	}

--- a/plugins/authentication/skeletonkey/skeletonkey.xml
+++ b/plugins/authentication/skeletonkey/skeletonkey.xml
@@ -10,10 +10,10 @@
     <author>Akeeba Ltd</author>
     <authorEmail>no-reply@akeeba.com</authorEmail>
     <authorUrl>https://www.akeeba.com</authorUrl>
-    <copyright>Copyright (c)2022-2025 Nicholas K. Dionysopoulos</copyright>
+    <copyright>Copyright (c)2022-2026 Nicholas K. Dionysopoulos</copyright>
     <license>GNU GPL v3 or later</license>
-    <creationDate>2026-04-21</creationDate>
-    <version>1.2.3</version>
+    <creationDate>2026-06-20</creationDate>
+    <version>1.2.4</version>
     <description>PLG_AUTHENTICATION_SKELETONKEY_XML_DESCRIPTION</description>
     <namespace path="src">Joomla\Plugin\Authentication\Skeletonkey</namespace>
 

--- a/plugins/authentication/skeletonkey/src/Extension/Skeletonkey.php
+++ b/plugins/authentication/skeletonkey/src/Extension/Skeletonkey.php
@@ -9,9 +9,7 @@ namespace Joomla\Plugin\Authentication\Skeletonkey\Extension;
 
 defined('_JEXEC') || die;
 
-use Joomla\Application\ApplicationInterface;
 use Joomla\CMS\Application\ApplicationHelper;
-use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -21,39 +19,41 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\CMS\User\UserHelper;
-use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Event\Event;
+use Joomla\Event\SubscriberInterface;
 use Joomla\Filter\InputFilter;
 use RuntimeException;
 
-class Skeletonkey extends CMSPlugin
+class Skeletonkey extends CMSPlugin implements SubscriberInterface, DatabaseAwareInterface
 {
+	use DatabaseAwareTrait;
+
 	private const COOKIE_PREFIX = "skeletonkey_";
 
 	/**
-	 * The application I am running under
-	 *
-	 * @var   ApplicationInterface|CMSApplication
-	 * @since 1.0.0
+	 * @inheritDoc
 	 */
-	protected $app;
-
-	/**
-	 * @var   DatabaseDriver
-	 * @since 1.0.0
-	 */
-	protected $db;
+	public static function getSubscribedEvents(): array
+	{
+		return [
+			'onUserAuthenticate' => 'onUserAuthenticate',
+			'onUserAfterLogout'  => 'onUserAfterLogout',
+		];
+	}
 
 	/**
 	 * Destroy any possible leftover cookie on logout
 	 *
-	 * @param   array  $options  Array holding options (length, timeToExpiration)
+	 * @param   Event  $event  The onUserAfterLogout event
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @noinspection PhpUnused
 	 * @since        1.0.0
 	 */
-	public function onUserAfterLogout(array $options): bool
+	public function onUserAfterLogout(Event $event): bool
 	{
 		$this->destroyCookie();
 
@@ -63,19 +63,33 @@ class Skeletonkey extends CMSPlugin
 	/**
 	 * Handles authentication with Skeleton Key
 	 *
-	 * @param   array    $credentials  Array holding the user credentials
-	 * @param   array    $options      Array of extra options
-	 * @param   object  &$response     Authentication response object
+	 * @param   Event  $event  The onUserAuthenticate event
 	 *
 	 * @return  bool  True on successful authentication
 	 * @since   1.0.0
 	 *
 	 * @noinspection PhpUnused
 	 */
-	public function onUserAuthenticate(array $credentials, array $options, object &$response): bool
+	public function onUserAuthenticate(Event $event): bool
 	{
+		/**
+		 * Joomla 7 dispatches a concrete AuthenticationEvent which exposes the authentication response
+		 * through a typed getter. Joomla 4, 5 and 6 pass the response object as the event's 'subject'
+		 * argument. Either way it is the same object the Authentication helper reads back, so mutating
+		 * its properties below propagates the result.
+		 */
+		if (version_compare(JVERSION, '6.999.999', 'gt'))
+		{
+			/** @var \Joomla\CMS\Event\User\AuthenticationEvent $event */
+			$response = $event->getAuthenticationResponse();
+		}
+		else
+		{
+			$response = $event->getArgument('subject');
+		}
+
 		// Skeleton key only works in the frontend
-		if (!$this->app->isClient('site'))
+		if (!$this->getApplication()->isClient('site'))
 		{
 			return false;
 		}
@@ -90,7 +104,7 @@ class Skeletonkey extends CMSPlugin
 
 		// Get the cookie. If it does not exist, give up.
 		$cookieName  = self::COOKIE_PREFIX . $this->getHashedUserAgent();
-		$cookieValue = $this->app->getInput()->cookie->get($cookieName);
+		$cookieValue = $this->getApplication()->getInput()->cookie->get($cookieName);
 
 		if (!$cookieValue)
 		{
@@ -118,14 +132,14 @@ class Skeletonkey extends CMSPlugin
 		$now    = time();
 
 		// Remove expired tokens
-		$query = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-		                  ->delete($this->db->quoteName('#__user_keys'))
-		                  ->where($this->db->quoteName('time') . ' < :now')
+		$query = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+		                  ->delete($this->getDatabase()->quoteName('#__user_keys'))
+		                  ->where($this->getDatabase()->quoteName('time') . ' < :now')
 		                  ->bind(':now', $now);
 
 		try
 		{
-			$this->db->setQuery($query)->execute();
+			$this->getDatabase()->setQuery($query)->execute();
 		}
 		catch (RuntimeException $e)
 		{
@@ -133,18 +147,18 @@ class Skeletonkey extends CMSPlugin
 		}
 
 		// Find the matching record if it exists.
-		$query = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-		                  ->select($this->db->quoteName(['user_id', 'token', 'series', 'time']))
-		                  ->from($this->db->quoteName('#__user_keys'))
-		                  ->where($this->db->quoteName('series') . ' = :series')
-		                  ->where($this->db->quoteName('uastring') . ' = :uastring')
-		                  ->order($this->db->quoteName('time') . ' DESC')
+		$query = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+		                  ->select($this->getDatabase()->quoteName(['user_id', 'token', 'series', 'time']))
+		                  ->from($this->getDatabase()->quoteName('#__user_keys'))
+		                  ->where($this->getDatabase()->quoteName('series') . ' = :series')
+		                  ->where($this->getDatabase()->quoteName('uastring') . ' = :uastring')
+		                  ->order($this->getDatabase()->quoteName('time') . ' DESC')
 		                  ->bind(':series', $series)
 		                  ->bind(':uastring', $cookieName);
 
 		try
 		{
-			$results = $this->db->setQuery($query)->loadObjectList();
+			$results = $this->getDatabase()->setQuery($query)->loadObjectList();
 		}
 		catch (RuntimeException $e)
 		{
@@ -172,14 +186,14 @@ class Skeletonkey extends CMSPlugin
 			 * Either the series was guessed correctly or a cookie was stolen and used twice (once by attacker and once by victim).
 			 * Delete all tokens for this user!
 			 */
-			$query = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-			                  ->delete($this->db->quoteName('#__user_keys'))
-			                  ->where($this->db->quoteName('user_id') . ' = :userid')
+			$query = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+			                  ->delete($this->getDatabase()->quoteName('#__user_keys'))
+			                  ->where($this->getDatabase()->quoteName('user_id') . ' = :userid')
 			                  ->bind(':userid', $results[0]->user_id);
 
 			try
 			{
-				$this->db->setQuery($query)->execute();
+				$this->getDatabase()->setQuery($query)->execute();
 			}
 			catch (RuntimeException $e)
 			{
@@ -202,16 +216,16 @@ class Skeletonkey extends CMSPlugin
 		}
 
 		// Make sure there really is a user with this name and get the data for the session.
-		$query = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-		                  ->select($this->db->quoteName(['id', 'username', 'password']))
-		                  ->from($this->db->quoteName('#__users'))
-		                  ->where($this->db->quoteName('username') . ' = :userid')
-		                  ->where($this->db->quoteName('requireReset') . ' = 0')
+		$query = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+		                  ->select($this->getDatabase()->quoteName(['id', 'username', 'password']))
+		                  ->from($this->getDatabase()->quoteName('#__users'))
+		                  ->where($this->getDatabase()->quoteName('username') . ' = :userid')
+		                  ->where($this->getDatabase()->quoteName('requireReset') . ' = 0')
 		                  ->bind(':userid', $results[0]->user_id);
 
 		try
 		{
-			$result = $this->db->setQuery($query)->loadObject();
+			$result = $this->getDatabase()->setQuery($query)->loadObject();
 		}
 		catch (RuntimeException $e)
 		{
@@ -259,13 +273,13 @@ class Skeletonkey extends CMSPlugin
 	private function destroyCookie()
 	{
 		// Skeleton key only works in the frontend
-		if (!$this->app->isClient('site'))
+		if (!$this->getApplication()->isClient('site'))
 		{
 			return;
 		}
 
 		$cookieName  = self::COOKIE_PREFIX . $this->getHashedUserAgent();
-		$cookieValue = $this->app->getInput()->cookie->get($cookieName);
+		$cookieValue = $this->getApplication()->getInput()->cookie->get($cookieName);
 
 		// There are no cookies to delete.
 		if (!$cookieValue)
@@ -280,14 +294,14 @@ class Skeletonkey extends CMSPlugin
 		$series = $filter->clean($cookieArray[1], 'ALNUM');
 
 		// Remove the record from the database
-		$query = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-		                  ->delete($this->db->quoteName('#__user_keys'))
-		                  ->where($this->db->quoteName('series') . ' = :series')
+		$query = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+		                  ->delete($this->getDatabase()->quoteName('#__user_keys'))
+		                  ->where($this->getDatabase()->quoteName('series') . ' = :series')
 		                  ->bind(':series', $series);
 
 		try
 		{
-			$this->db->setQuery($query)->execute();
+			$this->getDatabase()->setQuery($query)->execute();
 		}
 		catch (RuntimeException $e)
 		{
@@ -295,19 +309,19 @@ class Skeletonkey extends CMSPlugin
 		}
 
 		// Destroy the cookie. Takes into account Joomla 6 changes in Cookie::set().
-		$cookiePath   = $this->app->get('cookie_path', '/') ?: '/';
-		$cookieDomain = $this->app->get('cookie_domain', '');
+		$cookiePath   = $this->getApplication()->get('cookie_path', '/') ?: '/';
+		$cookieDomain = $this->getApplication()->get('cookie_domain', '');
 
 		if (!version_compare(JVERSION, '5.999.999', 'le'))
 		{
-			$this->app->getInput()->cookie->set(
+			$this->getApplication()->getInput()->cookie->set(
 				$cookieName,
 				'',
 				[
 					'expires'  => 1,
 					'path'     => $cookiePath,
 					'domain'   => $cookieDomain,
-					'secure'   => $this->app->isHttpsForced(),
+					'secure'   => $this->getApplication()->isHttpsForced(),
 					'httponly' => true,
 					// Currently ignored in Joomla!. Added in hopes of future support...
 					'samesite' => 'Strict',
@@ -318,7 +332,7 @@ class Skeletonkey extends CMSPlugin
 		}
 
 		// Joomla 5.x support.
-		$this->app->getInput()->cookie->set($cookieName, '', 1, $cookiePath, $cookieDomain);
+		$this->getApplication()->getInput()->cookie->set($cookieName, '', 1, $cookiePath, $cookieDomain);
 	}
 
 	/**
@@ -330,7 +344,7 @@ class Skeletonkey extends CMSPlugin
 	 */
 	private function getHashedUserAgent(): string
 	{
-		return ApplicationHelper::getHash(Uri::root() . $this->app->client->userAgent);
+		return ApplicationHelper::getHash(Uri::root() . $this->getApplication()->client->userAgent);
 	}
 
 }

--- a/plugins/system/skeletonkey/services/provider.php
+++ b/plugins/system/skeletonkey/services/provider.php
@@ -8,7 +8,9 @@
 defined('_JEXEC') || die;
 
 use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -32,7 +34,12 @@ return new class implements ServiceProviderInterface {
 				$config  = (array) PluginHelper::getPlugin('system', 'skeletonkey');
 				$subject = $container->get(DispatcherInterface::class);
 
-				return new Skeletonkey($subject, $config);
+				$plugin = new Skeletonkey($subject, $config);
+
+				$plugin->setApplication(Factory::getApplication());
+				$plugin->setDatabase($container->get(DatabaseInterface::class));
+
+				return $plugin;
 			}
 		);
 	}

--- a/plugins/system/skeletonkey/skeletonkey.xml
+++ b/plugins/system/skeletonkey/skeletonkey.xml
@@ -10,10 +10,10 @@
     <author>Akeeba Ltd</author>
     <authorEmail>no-reply@akeeba.com</authorEmail>
     <authorUrl>https://www.akeeba.com</authorUrl>
-    <copyright>Copyright (c)2022-2025 Nicholas K. Dionysopoulos</copyright>
+    <copyright>Copyright (c)2022-2026 Nicholas K. Dionysopoulos</copyright>
     <license>GNU GPL v3 or later</license>
-    <creationDate>2026-04-21</creationDate>
-    <version>1.2.3</version>
+    <creationDate>2026-06-20</creationDate>
+    <version>1.2.4</version>
     <description>PLG_SYSTEM_SKELETONKEY_XML_DESCRIPTION</description>
     <namespace path="src">Joomla\Plugin\System\Skeletonkey</namespace>
 

--- a/plugins/system/skeletonkey/src/Extension/Skeletonkey.php
+++ b/plugins/system/skeletonkey/src/Extension/Skeletonkey.php
@@ -9,7 +9,6 @@ namespace Joomla\Plugin\System\Skeletonkey\Extension;
 
 defined('_JEXEC') || die;
 
-use Joomla\Application\ApplicationInterface;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Event\View\DisplayEvent;
@@ -23,7 +22,8 @@ use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Component\Users\Administrator\View\Users\HtmlView as UsersHtmlView;
-use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Event\Event;
 use Joomla\Event\SubscriberInterface;
@@ -31,23 +31,11 @@ use Joomla\Utilities\ArrayHelper;
 use RuntimeException;
 use Throwable;
 
-class Skeletonkey extends CMSPlugin implements SubscriberInterface
+class Skeletonkey extends CMSPlugin implements SubscriberInterface, DatabaseAwareInterface
 {
+	use DatabaseAwareTrait;
+
 	private const COOKIE_PREFIX = "skeletonkey_";
-
-	/**
-	 * The application I am running under
-	 *
-	 * @var   ApplicationInterface|CMSApplication
-	 * @since 1.0.0
-	 */
-	protected $app;
-
-	/**
-	 * @var    DatabaseDriver
-	 * @since  1.0.0
-	 */
-	protected $db;
 
 	/**
 	 * Affects constructor behavior. If true, language files will be loaded automatically.
@@ -115,13 +103,13 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 	public function onBeforeDisplay(Event $event)
 	{
 		// Make sure this is the backend.
-		if (!($this->app instanceof CMSApplication) || !$this->app->isClient('administrator'))
+		if (!($this->getApplication() instanceof CMSApplication) || !$this->getApplication()->isClient('administrator'))
 		{
 			return;
 		}
 
 		// Make sure the current user is allowed to log into the site as another user.
-		$currentUser = $this->app->getIdentity();
+		$currentUser = $this->getApplication()->getIdentity();
 
 		if (!($currentUser instanceof User) || empty(array_intersect($currentUser->getAuthorisedGroups(), $this->allowedControlGroups)))
 		{
@@ -152,7 +140,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		{
 			$this->loadLanguage();
 
-			$this->app->enqueueMessage(Text::_('PLG_SYSTEM_SKELETONKEY_LBL_NOAUTHPLUGIN'), CMSApplication::MSG_ERROR);
+			$this->getApplication()->enqueueMessage(Text::_('PLG_SYSTEM_SKELETONKEY_LBL_NOAUTHPLUGIN'), CMSApplication::MSG_ERROR);
 
 			return;
 		}
@@ -184,7 +172,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Add our custom JavaScript
-		$document = $this->app->getDocument();
+		$document = $this->getApplication()->getDocument();
 		$wam      = $document->getWebAssetManager();
 		$wam->getRegistry()->addExtensionRegistryFile('plg_system_skeletonkey');
 		$document->addScriptOptions('plg_system_skeletonkey', [
@@ -209,7 +197,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 	public function onAfterInitialise(Event $event)
 	{
 		// Skeleton key only works in the frontend
-		if (!$this->app->isClient('site'))
+		if (!$this->getApplication()->isClient('site'))
 		{
 			return;
 		}
@@ -223,10 +211,10 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		// If the cookie is set try to log in the user using it
 		$cookieName = self::COOKIE_PREFIX . $this->getHashedUserAgent();
 
-		if ($this->app->getInput()->cookie->get($cookieName))
+		if ($this->getApplication()->getInput()->cookie->get($cookieName))
 		{
 
-			$this->app->login(['username' => ''], ['silent' => true]);
+			$this->getApplication()->login(['username' => ''], ['silent' => true]);
 		}
 	}
 
@@ -249,7 +237,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Make sure this is the backend.
-		if (!($this->app instanceof CMSApplication) || !$this->app->isClient('administrator'))
+		if (!($this->getApplication() instanceof CMSApplication) || !$this->getApplication()->isClient('administrator'))
 		{
 			$this->addEventResult($event, false);
 
@@ -257,7 +245,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Make sure the current user is allowed to log into the site as another user.
-		$currentUser = $this->app->getIdentity();
+		$currentUser = $this->getApplication()->getIdentity();
 
 		if (!($currentUser instanceof User) || empty(array_intersect($currentUser->getAuthorisedGroups(), $this->allowedControlGroups)))
 		{
@@ -276,7 +264,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 
 		// Make sure the requested user exists
 		/** @var User $user */
-		$userId = $this->app->getInput()->get->getInt('user_id');
+		$userId = $this->getApplication()->getInput()->get->getInt('user_id');
 		$user   = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($userId);
 
 		if ($user->id <= 0 || $user->id != $userId)
@@ -303,7 +291,11 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		// Trigger the Action Log plugin
 		$this->getDispatcher()->dispatch(
 			'onSkeletonKeyRequestLogin',
-			new Event('onSkeletonKeyRequestLogin', [$currentUser, $user, $createdCookie])
+			new Event('onSkeletonKeyRequestLogin', [
+				'controlUser'   => $currentUser,
+				'targetUser'    => $user,
+				'createdCookie' => $createdCookie,
+			])
 		);
 
 		// Return the event result back to com_ajax
@@ -339,15 +331,15 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		do
 		{
 			$series = UserHelper::genRandomPassword(20);
-			$query  = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true))
-				->select($this->db->quoteName('series'))
-				->from($this->db->quoteName('#__user_keys'))
-				->where($this->db->quoteName('series') . ' = :series')
+			$query  = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true))
+				->select($this->getDatabase()->quoteName('series'))
+				->from($this->getDatabase()->quoteName('#__user_keys'))
+				->where($this->getDatabase()->quoteName('series') . ' = :series')
 				->bind(':series', $series);
 
 			try
 			{
-				$results = $this->db->setQuery($query)->loadResult();
+				$results = $this->getDatabase()->setQuery($query)->loadResult();
 
 				if ($results === null)
 				{
@@ -379,20 +371,20 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		try
 		{
 			$future = (time() + $lifetime);
-			$query  = (method_exists($this->db, 'createQuery') ? $this->db->createQuery() : $this->db->getQuery(true));
+			$query  = (method_exists($this->getDatabase(), 'createQuery') ? $this->getDatabase()->createQuery() : $this->getDatabase()->getQuery(true));
 			$query
-				->insert($this->db->quoteName('#__user_keys'))
-				->set($this->db->quoteName('user_id') . ' = :userid')
-				->set($this->db->quoteName('series') . ' = :series')
-				->set($this->db->quoteName('uastring') . ' = :uastring')
-				->set($this->db->quoteName('time') . ' = :time')
-				->set($this->db->quoteName('token') . ' = :token')
+				->insert($this->getDatabase()->quoteName('#__user_keys'))
+				->set($this->getDatabase()->quoteName('user_id') . ' = :userid')
+				->set($this->getDatabase()->quoteName('series') . ' = :series')
+				->set($this->getDatabase()->quoteName('uastring') . ' = :uastring')
+				->set($this->getDatabase()->quoteName('time') . ' = :time')
+				->set($this->getDatabase()->quoteName('token') . ' = :token')
 				->bind(':userid', $user->username)
 				->bind(':series', $series)
 				->bind(':uastring', $cookieName)
 				->bind(':time', $future, ParameterType::INTEGER)
 				->bind(':token', $hashedToken);
-			$this->db->setQuery($query)->execute();
+			$this->getDatabase()->setQuery($query)->execute();
 		}
 		catch (RuntimeException $e)
 		{
@@ -400,20 +392,20 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Set the cookie. Takes into account Joomla 6 changes in Cookie::set().
-		$cookiePath   = $this->app->get('cookie_path', '/') ?: '/';
-		$cookieDomain = $this->app->get('cookie_domain', '');
+		$cookiePath   = $this->getApplication()->get('cookie_path', '/') ?: '/';
+		$cookieDomain = $this->getApplication()->get('cookie_domain', '');
 
 		// Joomla 6.x and later
 		if (version_compare(JVERSION, '5.999.999', 'gt'))
 		{
-			$this->app->getInput()->cookie->set(
+			$this->getApplication()->getInput()->cookie->set(
 				$cookieName,
 				$cookieValue,
 				[
 					'expires'  => $future,
 					'path'     => $cookiePath,
 					'domain'   => $cookieDomain,
-					'secure'   => $this->app->isHttpsForced(),
+					'secure'   => $this->getApplication()->isHttpsForced(),
 					'httponly' => true,
 					// Currently ignored in Joomla!. Added in hopes of future support...
 					'samesite' => 'Strict',
@@ -424,13 +416,13 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 		}
 
 		// Joomla 5.x support
-		$this->app->getInput()->cookie->set(
+		$this->getApplication()->getInput()->cookie->set(
 			$cookieName,
 			$cookieValue,
 			$future,
 			$cookiePath,
 			$cookieDomain,
-			$this->app->isHttpsForced(),
+			$this->getApplication()->isHttpsForced(),
 			true
 		);
 
@@ -482,7 +474,7 @@ class Skeletonkey extends CMSPlugin implements SubscriberInterface
 	 */
 	private function getHashedUserAgent(): string
 	{
-		return ApplicationHelper::getHash(Uri::root() . $this->app->client->userAgent);
+		return ApplicationHelper::getHash(Uri::root() . $this->getApplication()->client->userAgent);
 	}
 
 	/**

--- a/updates/skeletonkey.xml
+++ b/updates/skeletonkey.xml
@@ -9,6 +9,26 @@
         <name>Skeleton Key</name>
         <element>pkg_skeletonkey</element>
         <type>package</type>
+        <version>1.2.4</version>
+        <infourl title="Skeleton Key 1.2.4">https://github.com/akeeba/skeletonkey/releases/tag/1.2.4</infourl>
+        <downloads>
+            <downloadurl type="full" format="zip">
+                https://github.com/akeeba/skeletonkey/releases/download/1.2.4/pkg_skeletonkey-1.2.4.zip
+            </downloadurl>
+        </downloads>
+        <tags>
+            <tag>stable</tag>
+        </tags>
+        <targetplatform name="joomla" version="4.[4-9]|5.[0-9]|6.[0-9]|7.0"/>
+        <!-- TODO: replace with the real package checksum when the 1.2.4 release ZIP is built -->
+        <sha256>0000000000000000000000000000000000000000000000000000000000000000</sha256>
+        <client>site</client>
+        <php_minimum>7.2</php_minimum>
+    </update>
+    <update>
+        <name>Skeleton Key</name>
+        <element>pkg_skeletonkey</element>
+        <type>package</type>
         <version>1.2.1</version>
         <infourl title="Skeleton Key 1.2.1">https://github.com/akeeba/skeletonkey/releases/tag/1.2.1</infourl>
         <downloads>


### PR DESCRIPTION
## Summary
Refactor all three Skeleton Key plugins to achieve Joomla 7 compatibility by removing reliance on Joomla's removed automatic `$app` and `$db` property population. Application and database instances are now injected through the service providers using `DatabaseAwareTrait` and explicit setter calls.

## Key Changes

**Authentication Plugin** (`plugins/authentication/skeletonkey/`)
- Implement `DatabaseAwareInterface` and use `DatabaseAwareTrait` instead of manual `$db` property
- Implement `SubscriberInterface` and add `getSubscribedEvents()` to declare event subscriptions
- Update `onUserAuthenticate()` to accept `Event` object instead of separate `$credentials`, `$options`, `$response` parameters
- Add version-gated logic to extract authentication response from `AuthenticationEvent::getAuthenticationResponse()` (Joomla 7+) or event subject (Joomla 4–6)
- Replace all `$this->app` calls with `$this->getApplication()` and `$this->db` with `$this->getDatabase()`
- Update `onUserAfterLogout()` signature to accept `Event` object
- Inject application and database in `services/provider.php` via `setApplication()` and `setDatabase()`

**System Plugin** (`plugins/system/skeletonkey/`)
- Implement `DatabaseAwareInterface` and use `DatabaseAwareTrait`
- Replace all `$this->app` calls with `$this->getApplication()` and `$this->db` with `$this->getDatabase()`
- Update `onAjaxSkeletonkey()` to pass named arguments to `onSkeletonKeyRequestLogin` event (instead of positional array)
- Inject application and database in `services/provider.php`

**Action Log Plugin** (`plugins/actionlog/skeletonkey/`)
- Update `onSkeletonKeyRequestLogin()` to extract named event arguments (`controlUser`, `targetUser`, `createdCookie`) instead of unpacking positional array

**Service Providers**
- Import `Factory` and `DatabaseInterface`
- Instantiate plugins and call `setApplication(Factory::getApplication())` and `setDatabase($container->get(DatabaseInterface::class))`

**Metadata & Release**
- Bump version to 1.2.4 across all plugin manifests and build templates
- Update copyright year to 2026
- Add update entry to `updates/skeletonkey.xml` for version 1.2.4
- Update `CHANGELOG` and `RELEASENOTES.md` documenting Joomla 7 compatibility improvements
- Raise minimum Joomla requirement to 4.4 (as noted in CHANGELOG)

## Implementation Details
- All database access now flows through `getDatabase()` getter provided by `DatabaseAwareTrait`
- Application access flows through `getApplication()` (inherited from `CMSPlugin`)
- Event handling in authentication plugin is backward-compatible: version checks determine whether to use the new `AuthenticationEvent` API or fall back to event subject
- Named event arguments improve clarity and reduce coupling to argument order

https://claude.ai/code/session_019rn7ZGu4EBdTeeL5o5Ahju